### PR TITLE
Make Pranjeet conversation mode guild-wide

### DIFF
--- a/apps/pranjeet/src/redis.ts
+++ b/apps/pranjeet/src/redis.ts
@@ -148,9 +148,15 @@ export async function getConversationMode(guildId: string, userId: string): Prom
   const c = getClient();
   if (!c) return false;
   try {
-    const key = `${CONVERSATION_KEY_PREFIX}${guildId}:${userId}`;
-    const value = await c.get(key);
-    return value === '1';
+    // Preferred key: guild-wide conversation mode.
+    const guildKey = `${CONVERSATION_KEY_PREFIX}${guildId}`;
+    const guildValue = await c.get(guildKey);
+    if (guildValue === '1') return true;
+
+    // Backward compatibility with older user-scoped key.
+    const userKey = `${CONVERSATION_KEY_PREFIX}${guildId}:${userId}`;
+    const userValue = await c.get(userKey);
+    return userValue === '1';
   } catch {
     return false;
   }

--- a/apps/raincloud/commands/voice/chat.js
+++ b/apps/raincloud/commands/voice/chat.js
@@ -22,12 +22,14 @@ module.exports = {
     .addSubcommand((subcommand) =>
       subcommand
         .setName('on')
-        .setDescription('Turn on conversation mode — your voice will be sent to Grok')
+        .setDescription(
+          'Turn on conversation mode — everyone in the voice channel can talk to Grok'
+        )
     )
     .addSubcommand((subcommand) =>
       subcommand
         .setName('off')
-        .setDescription('Turn off conversation mode — voice commands work as usual')
+        .setDescription('Turn off conversation mode — everyone returns to normal voice commands')
     )
     .addSubcommand((subcommand) =>
       subcommand.setName('toggle').setDescription('Toggle conversation mode on or off')
@@ -54,11 +56,11 @@ module.exports = {
         case 'on': {
           await voiceStateManager.setConversationMode(guildId, userId, true);
           log.info(
-            `Conversation mode on for user ${interaction.user.tag} in guild ${interaction.guild?.name}`
+            `Conversation mode on for guild ${interaction.guild?.name} (requested by ${interaction.user.tag})`
           );
           await interaction.reply({
             content:
-              '✅ **Conversation mode on.** Your voice will be sent to Grok until you turn it off. Use `/chat off` or `/chat toggle` to exit.',
+              '✅ **Conversation mode on.** Everyone in the active voice channel can talk to Grok until it is turned off. Use `/chat off` or `/chat toggle` to exit.',
             flags: MessageFlags.Ephemeral,
           });
           break;
@@ -67,10 +69,10 @@ module.exports = {
         case 'off': {
           await voiceStateManager.setConversationMode(guildId, userId, false);
           log.info(
-            `Conversation mode off for user ${interaction.user.tag} in guild ${interaction.guild?.name}`
+            `Conversation mode off for guild ${interaction.guild?.name} (requested by ${interaction.user.tag})`
           );
           await interaction.reply({
-            content: '✅ **Conversation mode off.** Voice commands work as usual.',
+            content: '✅ **Conversation mode off.** Everyone is back to normal voice commands.',
             flags: MessageFlags.Ephemeral,
           });
           break;
@@ -81,12 +83,12 @@ module.exports = {
           const next = !current;
           await voiceStateManager.setConversationMode(guildId, userId, next);
           log.info(
-            `Conversation mode toggled to ${next} for user ${interaction.user.tag} in guild ${interaction.guild?.name}`
+            `Conversation mode toggled to ${next} for guild ${interaction.guild?.name} (requested by ${interaction.user.tag})`
           );
           await interaction.reply({
             content: next
-              ? '✅ **Conversation mode on.** Your voice will be sent to Grok. Use `/chat toggle` again to turn off.'
-              : '✅ **Conversation mode off.** Voice commands work as usual.',
+              ? '✅ **Conversation mode on.** Everyone in the active voice channel can talk to Grok. Use `/chat toggle` again to turn off.'
+              : '✅ **Conversation mode off.** Everyone is back to normal voice commands.',
             flags: MessageFlags.Ephemeral,
           });
           break;
@@ -96,7 +98,7 @@ module.exports = {
           const isOn = await voiceStateManager.getConversationMode(guildId, userId);
           await interaction.reply({
             content: isOn
-              ? '✅ **Conversation mode is on.** Your voice is being sent to Grok.'
+              ? '✅ **Conversation mode is on.** Everyone in the active voice channel can talk to Grok.'
               : '❌ **Conversation mode is off.** Use `/chat on` to start chatting.',
             flags: MessageFlags.Ephemeral,
           });

--- a/apps/raincloud/lib/voiceStateManager.ts
+++ b/apps/raincloud/lib/voiceStateManager.ts
@@ -183,31 +183,42 @@ export class VoiceStateManager {
   }
 
   /**
-   * Set conversation mode (Grok chat) for a user in a guild.
-   * When disabling, also clears the Grok response_id so the next session starts fresh.
+   * Set conversation mode (Grok chat) for a guild.
+   * userId is retained for backward compatibility and actor-specific cleanup.
+   * When disabling, also clears this actor's Grok response/history so their next session starts fresh.
    */
   async setConversationMode(guildId: string, userId: string, enabled: boolean): Promise<void> {
-    const key = `conversation:${guildId}:${userId}`;
+    const guildKey = `conversation:${guildId}`;
+    const userKey = `conversation:${guildId}:${userId}`;
     if (enabled) {
-      await this.redis.set(key, '1');
-      log.debug(`Set conversation mode on for user ${userId} in guild ${guildId}`);
+      // Guild-wide switch: once on, everyone in the active voice channel can talk to Grok.
+      await this.redis.set(guildKey, '1');
+      // Legacy compatibility for any older readers that still look up user-scoped keys.
+      await this.redis.set(userKey, '1');
+      log.debug(`Set conversation mode on for guild ${guildId} (requested by user ${userId})`);
     } else {
-      await this.redis.del(key);
+      await this.redis.del(guildKey);
+      await this.redis.del(userKey);
       const grokResponseKey = `grok:response_id:${guildId}:${userId}`;
       const grokHistoryKey = `grok:history:${guildId}:${userId}`;
       await this.redis.del(grokResponseKey);
       await this.redis.del(grokHistoryKey);
-      log.debug(`Set conversation mode off for user ${userId} in guild ${guildId}`);
+      log.debug(`Set conversation mode off for guild ${guildId} (requested by user ${userId})`);
     }
   }
 
   /**
-   * Get conversation mode for a user in a guild
+   * Get conversation mode for a guild.
+   * Falls back to the legacy user-scoped key for compatibility with older persisted state.
    */
   async getConversationMode(guildId: string, userId: string): Promise<boolean> {
-    const key = `conversation:${guildId}:${userId}`;
-    const data = await this.redis.get(key);
-    return data === '1';
+    const guildData = await this.redis.get(`conversation:${guildId}`);
+    if (guildData === '1') {
+      return true;
+    }
+
+    const userData = await this.redis.get(`conversation:${guildId}:${userId}`);
+    return userData === '1';
   }
 
   /** Valid xAI Voice Agent voices. */

--- a/apps/raincloud/server/routes/api.ts
+++ b/apps/raincloud/server/routes/api.ts
@@ -898,7 +898,7 @@ router.post(
   }
 );
 
-// GET /api/conversation-mode/:guildId - Get Grok conversation mode for the current user in the guild
+// GET /api/conversation-mode/:guildId - Get Grok conversation mode for the guild
 router.get(
   '/conversation-mode/:guildId',
   requireAuth,
@@ -926,7 +926,7 @@ router.get(
   }
 );
 
-// POST /api/conversation-mode - Turn Grok conversation mode on or off for the current user in the guild
+// POST /api/conversation-mode - Turn Grok conversation mode on or off for the guild
 router.post(
   '/conversation-mode',
   requireAuth,

--- a/ui/src/components/tabs/AdminTab.tsx
+++ b/ui/src/components/tabs/AdminTab.tsx
@@ -524,10 +524,10 @@ export default function AdminTab() {
             Grok conversation mode (voice)
           </div>
           <div className="text-xs text-text-secondary mb-4">
-            For the server selected in Run commands: when on, your voice is sent to Grok in real
-            time (Voice Agent). Turning on also enables voice listening for this server. Join a
-            voice channel with the bot and speak; ensure GROK_API_KEY is set on the voice worker. If
-            nothing happens, try turning off then on again.
+            For the server selected in Run commands: when on, everyone in the active voice channel
+            can talk to Grok in real time (Voice Agent). Turning on also enables voice listening for
+            this server. Join a voice channel with the bot and speak; ensure GROK_API_KEY is set on
+            the voice worker. If nothing happens, try turning off then on again.
           </div>
           {runGuildId ? (
             <div className="space-y-3">
@@ -593,7 +593,7 @@ export default function AdminTab() {
                   ))}
                 </select>
                 <div className="text-xs text-text-secondary mt-1">
-                  Voice for the Grok Voice Agent. Takes effect on your next conversation.
+                  Voice for the Grok Voice Agent. Takes effect for your next conversation.
                 </div>
                 {grokVoiceMutation.isError && (
                   <div className="text-xs text-danger-light mt-1">


### PR DESCRIPTION
## Summary
- switch conversation mode lookup/storage to guild-wide key so one `on` applies to everyone in the active voice channel
- keep fallback support for legacy user-scoped conversation keys
- update chat command/admin copy to reflect channel-wide behavior

## Validation
- eslint passed for edited backend files
- full workspace type-check currently fails due unrelated pre-existing repo issues