### PR TITLE
Slim conversation mode code paths

### DIFF
--- a/apps/pranjeet/src/redis.ts
+++ b/apps/pranjeet/src/redis.ts
@@ -25,7 +25,6 @@ function getClient(): IORedis | null {
   return client;
 }
 
-const CONVERSATION_KEY_PREFIX = 'conversation:';
 /** Mirrors raincloud VoiceStateManager: number of members with conversation mode on in this guild. */
 const CONVERSATION_ACTIVE_COUNT_PREFIX = 'conversation:active_count:';
 const GROK_RESPONSE_ID_KEY_PREFIX = 'grok:response_id:';
@@ -146,44 +145,15 @@ export async function getCustomPersona(
   }
 }
 
-export async function getConversationMode(guildId: string, userId: string): Promise<boolean> {
-  const c = getClient();
-  if (!c) return false;
-  try {
-    // Preferred key: guild-wide conversation mode.
-    const guildKey = `${CONVERSATION_KEY_PREFIX}${guildId}`;
-    const guildValue = await c.get(guildKey);
-    if (guildValue === '1') return true;
-
-    // Backward compatibility with older user-scoped key.
-    const userKey = `${CONVERSATION_KEY_PREFIX}${guildId}:${userId}`;
-    const userValue = await c.get(userKey);
-    return userValue === '1';
-  } catch {
-    return false;
-  }
-}
-
-/**
- * True if anyone in the guild has conversation mode on — voice routing uses this so all speakers
- * in VC get realtime Grok when at least one person opted in.
- */
+/** Guild-scoped conversation mode state used by voice routing. */
 export async function isGuildConversationModeActive(guildId: string): Promise<boolean> {
   const c = getClient();
   if (!c) return false;
   try {
     const countKey = `${CONVERSATION_ACTIVE_COUNT_PREFIX}${guildId}`;
     const raw = await c.get(countKey);
-    if (raw !== null) {
-      const n = parseInt(raw, 10);
-      return !Number.isNaN(n) && n > 0;
-    }
-    const pattern = `${CONVERSATION_KEY_PREFIX}${guildId}:*`;
-    const keys = await c.keys(pattern);
-    if (keys.length > 0) {
-      await c.set(countKey, String(keys.length));
-    }
-    return keys.length > 0;
+    const n = raw ? parseInt(raw, 10) : 0;
+    return !Number.isNaN(n) && n > 0;
   } catch {
     return false;
   }

--- a/apps/raincloud/commands/voice/chat.js
+++ b/apps/raincloud/commands/voice/chat.js
@@ -51,65 +51,63 @@ module.exports = {
       });
     }
 
+    const guildName = interaction.guild?.name ?? guildId;
+    const requesterTag = interaction.user.tag;
+    const replyEphemeral = (content) =>
+      interaction.reply({
+        content,
+        flags: MessageFlags.Ephemeral,
+      });
+    const setModeAndReply = async (enabled, message) => {
+      await voiceStateManager.setConversationMode(guildId, userId, enabled);
+      log.info(
+        `Conversation mode ${enabled ? 'on' : 'off'} for guild ${guildName} (requested by ${requesterTag})`
+      );
+      await replyEphemeral(message);
+    };
+
     try {
       switch (subcommand) {
         case 'on': {
-          await voiceStateManager.setConversationMode(guildId, userId, true);
-          log.info(
-            `Conversation mode on for guild ${interaction.guild?.name} (requested by ${interaction.user.tag})`
+          await setModeAndReply(
+            true,
+            '✅ **Conversation mode on.** Everyone in the active voice channel can talk to Grok until it is turned off. Use `/chat off` or `/chat toggle` to exit.'
           );
-          await interaction.reply({
-            content:
-              '✅ **Conversation mode on.** Everyone in the active voice channel can talk to Grok until it is turned off. Use `/chat off` or `/chat toggle` to exit.',
-            flags: MessageFlags.Ephemeral,
-          });
           break;
         }
 
         case 'off': {
-          await voiceStateManager.setConversationMode(guildId, userId, false);
-          log.info(
-            `Conversation mode off for guild ${interaction.guild?.name} (requested by ${interaction.user.tag})`
+          await setModeAndReply(
+            false,
+            '✅ **Conversation mode off.** Everyone is back to normal voice commands.'
           );
-          await interaction.reply({
-            content: '✅ **Conversation mode off.** Everyone is back to normal voice commands.',
-            flags: MessageFlags.Ephemeral,
-          });
           break;
         }
 
         case 'toggle': {
-          const current = await voiceStateManager.getConversationMode(guildId, userId);
+          const current = await voiceStateManager.getConversationMode(guildId);
           const next = !current;
-          await voiceStateManager.setConversationMode(guildId, userId, next);
-          log.info(
-            `Conversation mode toggled to ${next} for guild ${interaction.guild?.name} (requested by ${interaction.user.tag})`
-          );
-          await interaction.reply({
-            content: next
+          await setModeAndReply(
+            next,
+            next
               ? '✅ **Conversation mode on.** Everyone in the active voice channel can talk to Grok. Use `/chat toggle` again to turn off.'
-              : '✅ **Conversation mode off.** Everyone is back to normal voice commands.',
-            flags: MessageFlags.Ephemeral,
-          });
+              : '✅ **Conversation mode off.** Everyone is back to normal voice commands.'
+          );
           break;
         }
 
         case 'status': {
-          const isOn = await voiceStateManager.getConversationMode(guildId, userId);
-          await interaction.reply({
-            content: isOn
+          const isOn = await voiceStateManager.getConversationMode(guildId);
+          await replyEphemeral(
+            isOn
               ? '✅ **Conversation mode is on.** Everyone in the active voice channel can talk to Grok.'
-              : '❌ **Conversation mode is off.** Use `/chat on` to start chatting.',
-            flags: MessageFlags.Ephemeral,
-          });
+              : '❌ **Conversation mode is off.** Use `/chat on` to start chatting.'
+          );
           break;
         }
 
         default:
-          await interaction.reply({
-            content: '❌ Unknown subcommand.',
-            flags: MessageFlags.Ephemeral,
-          });
+          await replyEphemeral('❌ Unknown subcommand.');
       }
     } catch (error) {
       log.error(`Error executing chat command: ${error.message}`);

--- a/apps/raincloud/lib/voiceStateManager.ts
+++ b/apps/raincloud/lib/voiceStateManager.ts
@@ -182,84 +182,38 @@ export class VoiceStateManager {
     return data === '1'; // Default false if not set
   }
 
-  /** How many members in this guild have personal conversation mode enabled (for guild-wide voice routing). */
-  private conversationActiveCountKey(guildId: string): string {
+  /** Canonical guild-scoped conversation mode state (1=on, 0=off). */
+  private conversationModeKey(guildId: string): string {
     return `conversation:active_count:${guildId}`;
   }
 
   /**
-   * Set conversation mode (Grok chat) for a user in a guild.
-   * When disabling, also clears the Grok response_id so the next session starts fresh.
-   * Maintains `conversation:active_count:{guildId}` so voice can treat "anyone on" as on for everyone.
+   * Set conversation mode (Grok chat) for a guild.
+   * When disabling, also clears the requester's Grok session state so the next session starts fresh.
    */
   async setConversationMode(guildId: string, userId: string, enabled: boolean): Promise<void> {
-    const userKey = `conversation:${guildId}:${userId}`;
+    const modeKey = this.conversationModeKey(guildId);
+    await this.redis.set(modeKey, enabled ? '1' : '0');
 
-    if (enabled) {
-      const prev = await this.redis.get(userKey);
-      if (prev === '1') {
-        return;
-      }
-      await this.redis.set(userKey, '1');
-      log.debug(`Set conversation mode on for user ${userId} in guild ${guildId}`);
-    } else {
-      const prev = await this.redis.get(userKey);
-      if (prev !== '1') {
-        return;
-      }
-      await this.redis.del(userKey);
+    if (!enabled) {
       const grokResponseKey = `grok:response_id:${guildId}:${userId}`;
       const grokHistoryKey = `grok:history:${guildId}:${userId}`;
       await this.redis.del(grokResponseKey);
       await this.redis.del(grokHistoryKey);
-      log.debug(`Set conversation mode off for user ${userId} in guild ${guildId}`);
     }
-    await this.syncConversationActiveCount(guildId);
+    log.debug(`Set conversation mode ${enabled ? 'on' : 'off'} for guild ${guildId}`);
   }
 
-  /** Recompute member count from `conversation:{guildId}:*` user keys (excludes unrelated keys). */
-  private async syncConversationActiveCount(guildId: string): Promise<void> {
-    const pattern = `conversation:${guildId}:*`;
-    const keys = await this.redis.keys(pattern);
-    const countKey = this.conversationActiveCountKey(guildId);
-    if (keys.length === 0) {
-      await this.redis.del(countKey);
-    } else {
-      await this.redis.set(countKey, String(keys.length));
-    }
+  /** Get conversation mode for the guild-scoped behavior expected by chat controls. */
+  async getConversationMode(guildId: string): Promise<boolean> {
+    return await this.isGuildConversationModeActive(guildId);
   }
 
-  /**
-   * Get conversation mode for the guild-scoped behavior expected by chat controls.
-   * Returns true if any member has conversation mode on. Falls back to legacy keys.
-   */
-  async getConversationMode(guildId: string, userId: string): Promise<boolean> {
-    if (await this.isGuildConversationModeActive(guildId)) {
-      return true;
-    }
-
-    const guildData = await this.redis.get(`conversation:${guildId}`);
-    if (guildData === '1') {
-      return true;
-    }
-    const userData = await this.redis.get(`conversation:${guildId}:${userId}`);
-    return userData === '1';
-  }
-
-  /**
-   * True if at least one member has conversation mode on — voice uses this so everyone in VC
-   * gets realtime/Grok routing when anyone opted in.
-   */
+  /** Guild-scoped conversation mode state used by voice routing. */
   async isGuildConversationModeActive(guildId: string): Promise<boolean> {
-    const countKey = this.conversationActiveCountKey(guildId);
+    const countKey = this.conversationModeKey(guildId);
     const raw = await this.redis.get(countKey);
-    if (raw !== null) {
-      const n = parseInt(raw, 10);
-      return !Number.isNaN(n) && n > 0;
-    }
-    await this.syncConversationActiveCount(guildId);
-    const again = await this.redis.get(countKey);
-    const n = again ? parseInt(again, 10) : 0;
+    const n = raw ? parseInt(raw, 10) : 0;
     return !Number.isNaN(n) && n > 0;
   }
 

--- a/apps/raincloud/server/routes/api.ts
+++ b/apps/raincloud/server/routes/api.ts
@@ -910,14 +910,9 @@ router.get(
       return;
     }
     try {
-      const { id: userId } = getAuthUser(req);
-      if (!userId) {
-        res.status(401).json({ error: 'Authentication required' });
-        return;
-      }
       const multiBot = requireMultiBot(res);
       if (!multiBot) return;
-      const enabled = await multiBot.getVoiceStateManager().getConversationMode(guildId, userId);
+      const enabled = await multiBot.getVoiceStateManager().getConversationMode(guildId);
       res.json({ enabled });
     } catch (error) {
       const err = error as Error;


### PR DESCRIPTION
Summary
- make conversation mode strictly guild-scoped using a single Redis key path
- remove legacy fallback reads and KEYS-based recompute/scan logic
- simplify slash-chat command flow by collapsing repetitive branch boilerplate
- trim conversation-mode API read path to guild-only behavior

Verification
- node --check apps/raincloud/commands/voice/chat.js
- yarn workspace @rainbot/raincloud test --runInBand apps/raincloud/lib/__tests__/workerCoordinator.smoke.test.ts