### PR TITLE
test(utils): mock fs.existsSync in deployCommands.test (CI fix)

### DIFF
--- a/packages/utils/src/__tests__/deployCommands.test.ts
+++ b/packages/utils/src/__tests__/deployCommands.test.ts
@@ -13,6 +13,7 @@ jest.mock('../logger', () => ({
 
 // Mock fs - return empty to simulate no commands
 jest.mock('fs', () => ({
+  existsSync: jest.fn(() => false),
   readdirSync: jest.fn(() => []),
   statSync: jest.fn(),
 }));


### PR DESCRIPTION
Fixes CI failure on main after #199.

deployCommands.ts:25 calls \`fs.existsSync\` to choose between two
possible commands directory locations. The deployCommands.test.ts
mock for \`fs\` only stubbed \`readdirSync\` and \`statSync\`, so the
test's compiled \`fs_1.default.existsSync(...)\` call hit
\`undefined is not a function\`.

The suite has existed for a while but wasn't being run by raincloud's
jest (whose \`roots: ['<rootDir>']\` is apps/raincloud, so utils tests
were never discovered). Chunk 6 of the audit gave packages/utils its
own jest.config.js, surfacing this pre-existing gap.

Fix: add \`existsSync: jest.fn(() => false)\` to the mock. The mocked
readdirSync still returns \`[]\`, so the "no commands" path is taken
regardless of which branch existsSync picks.

Verification: \`yarn turbo run test\` -> 24/24 tasks pass locally.