### PR TITLE
Fix discordClient injection in raincloud

### DIFF
--- a/apps/raincloud/index.js
+++ b/apps/raincloud/index.js
@@ -145,6 +145,11 @@ server
 client.once(Events.ClientReady, async () => {
   log.info(`Discord client ready as ${client.user?.tag}`);
   server.setClient(client);
+  // Wire @rainbot/utils's discordClient getter so anything in utils/voice/* that
+  // calls getDiscordClient() resolves to the live raincloud client. Set after
+  // server.setClient so the getter immediately returns a non-null client.
+  const { setDiscordClientGetter } = require('@rainbot/utils/voice/discordClient');
+  setDiscordClientGetter(() => server.getClient());
   try {
     const MultiBotService = require('./dist/apps/raincloud/lib/multiBotService');
     const redisUrl = config.redisUrl || process.env['REDIS_URL'];

--- a/packages/utils/src/voice/discordClient.ts
+++ b/packages/utils/src/voice/discordClient.ts
@@ -4,34 +4,15 @@ type ClientGetter = () => Client | null;
 
 let clientGetter: ClientGetter | null = null;
 
+/**
+ * Inject the source of the Discord client. Hosts that consume @rainbot/utils
+ * MUST call this once their client is constructed (e.g. apps/raincloud/index.js
+ * calls it after server.setClient). Without it getDiscordClient returns null.
+ */
 export function setDiscordClientGetter(getter: ClientGetter): void {
   clientGetter = getter;
 }
 
 export function getDiscordClient(): Client | null {
-  if (clientGetter) {
-    return clientGetter();
-  }
-
-  try {
-    const serverClient = require('../../server/client') as { getClient?: ClientGetter };
-    if (serverClient?.getClient) {
-      return serverClient.getClient();
-    }
-  } catch {
-    // Ignore and try next fallback.
-  }
-
-  try {
-    const raincloudClient = require('../../apps/raincloud/server/client') as {
-      getClient?: ClientGetter;
-    };
-    if (raincloudClient?.getClient) {
-      return raincloudClient.getClient();
-    }
-  } catch {
-    // Ignore and fall through.
-  }
-
-  return null;
+  return clientGetter ? clientGetter() : null;
 }


### PR DESCRIPTION
Chunk-6 move broke the relative-path require fallbacks in discordClient.ts. Wire setDiscordClientGetter from apps/raincloud/index.js.