### PR TITLE
Hotfix: rewrite raincloud .js requires to @rainbot/utils

### DIFF
--- a/apps/raincloud/commands/voice/autoplay.js
+++ b/apps/raincloud/commands/voice/autoplay.js
@@ -2,7 +2,7 @@
  * Autoplay command - Multi-bot architecture version
  */
 const { SlashCommandBuilder } = require('discord.js');
-const { createLogger } = require('../../dist/utils/logger');
+const { createLogger } = require('@rainbot/utils/logger');
 const { getMultiBotService } = require('../utils/commandHelpers');
 const {
   replySuccess,

--- a/apps/raincloud/commands/voice/chat.js
+++ b/apps/raincloud/commands/voice/chat.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder, MessageFlags } = require('discord.js');
-const { createLogger } = require('../../dist/utils/logger');
+const { createLogger } = require('@rainbot/utils/logger');
 
 const log = createLogger('CHAT_CMD');
 

--- a/apps/raincloud/commands/voice/clear.js
+++ b/apps/raincloud/commands/voice/clear.js
@@ -2,7 +2,7 @@
  * Clear command - Multi-bot architecture version
  */
 const { SlashCommandBuilder } = require('discord.js');
-const { createLogger } = require('../../dist/utils/logger');
+const { createLogger } = require('@rainbot/utils/logger');
 const { getMultiBotService } = require('../utils/commandHelpers');
 const {
   replySuccess,

--- a/apps/raincloud/commands/voice/join.js
+++ b/apps/raincloud/commands/voice/join.js
@@ -5,7 +5,7 @@
 const { SlashCommandBuilder, MessageFlags } = require('discord.js');
 const { checkVoicePermissions, getMultiBotService } = require('../utils/commandHelpers');
 const { replyError, replyWorkerUnavailable } = require('../utils/responseBuilder');
-const { createLogger } = require('../../dist/utils/logger');
+const { createLogger } = require('@rainbot/utils/logger');
 
 const log = createLogger('JOIN');
 
@@ -50,7 +50,7 @@ module.exports = {
         return;
       }
 
-      const voiceManager = require('../../dist/utils/voiceManager');
+      const voiceManager = require('@rainbot/utils/voiceManager');
       await voiceManager.joinChannel(voiceChannel);
       log.info(`Joined ${voiceChannel.name} in ${interaction.guild.name} (orchestrator only)`);
       await interaction.reply({

--- a/apps/raincloud/commands/voice/leave.js
+++ b/apps/raincloud/commands/voice/leave.js
@@ -3,7 +3,7 @@
  * Disconnects all worker bots from voice channel
  */
 const { SlashCommandBuilder } = require('discord.js');
-const { createLogger } = require('../../dist/utils/logger');
+const { createLogger } = require('@rainbot/utils/logger');
 const { getMultiBotService } = require('../utils/commandHelpers');
 const {
   replySuccess,

--- a/apps/raincloud/commands/voice/np.js
+++ b/apps/raincloud/commands/voice/np.js
@@ -2,7 +2,7 @@
  * Now Playing command - Multi-bot architecture version
  */
 const { SlashCommandBuilder } = require('discord.js');
-const { createPlayerMessage } = require('../../dist/utils/playerEmbed');
+const { createPlayerMessage } = require('@rainbot/utils/playerEmbed');
 const { getMultiBotService } = require('../utils/commandHelpers');
 const {
   replyWorkerUnavailable,

--- a/apps/raincloud/commands/voice/pause.js
+++ b/apps/raincloud/commands/voice/pause.js
@@ -2,7 +2,7 @@
  * Pause command - Multi-bot architecture version
  */
 const { SlashCommandBuilder } = require('discord.js');
-const { createLogger } = require('../../dist/utils/logger');
+const { createLogger } = require('@rainbot/utils/logger');
 const { getMultiBotService } = require('../utils/commandHelpers');
 const {
   replySuccess,

--- a/apps/raincloud/commands/voice/play.js
+++ b/apps/raincloud/commands/voice/play.js
@@ -3,7 +3,7 @@
  * Soundboard choices (from autocomplete) → HungerBot. Music/URLs → Rainbot.
  */
 const { SlashCommandBuilder } = require('discord.js');
-const { createLogger } = require('../../dist/utils/logger');
+const { createLogger } = require('@rainbot/utils/logger');
 const { getMultiBotService } = require('../utils/commandHelpers');
 const { replyError, replyWorkerUnavailable } = require('../utils/responseBuilder');
 

--- a/apps/raincloud/commands/voice/queue.js
+++ b/apps/raincloud/commands/voice/queue.js
@@ -8,7 +8,7 @@ const {
   getMultiBotService,
 } = require('../utils/commandHelpers');
 const { replyNotInVoice, replyWorkerUnavailable } = require('../utils/responseBuilder');
-const { createLogger } = require('../../dist/utils/logger');
+const { createLogger } = require('@rainbot/utils/logger');
 
 const log = createLogger('QUEUE_CMD');
 

--- a/apps/raincloud/commands/voice/skip.js
+++ b/apps/raincloud/commands/voice/skip.js
@@ -2,7 +2,7 @@
  * Skip command - Multi-bot architecture version
  */
 const { SlashCommandBuilder } = require('discord.js');
-const { createLogger } = require('../../dist/utils/logger');
+const { createLogger } = require('@rainbot/utils/logger');
 const { getMultiBotService } = require('../utils/commandHelpers');
 const {
   replySuccess,

--- a/apps/raincloud/commands/voice/stop.js
+++ b/apps/raincloud/commands/voice/stop.js
@@ -2,7 +2,7 @@
  * Stop command - Multi-bot architecture version
  */
 const { SlashCommandBuilder } = require('discord.js');
-const { createLogger } = require('../../dist/utils/logger');
+const { createLogger } = require('@rainbot/utils/logger');
 const { getMultiBotService } = require('../utils/commandHelpers');
 const {
   replySuccess,

--- a/apps/raincloud/commands/voice/voice-control.js
+++ b/apps/raincloud/commands/voice/voice-control.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder, PermissionFlagsBits, MessageFlags } = require('discord.js');
-const { createLogger } = require('../../dist/utils/logger');
+const { createLogger } = require('@rainbot/utils/logger');
 
 const log = createLogger('VOICE_CONTROL_CMD');
 

--- a/apps/raincloud/commands/voice/vol.js
+++ b/apps/raincloud/commands/voice/vol.js
@@ -2,7 +2,7 @@
  * Volume command - Multi-bot architecture version
  */
 const { SlashCommandBuilder } = require('discord.js');
-const { createLogger } = require('../../dist/utils/logger');
+const { createLogger } = require('@rainbot/utils/logger');
 const { getMultiBotService } = require('../utils/commandHelpers');
 const {
   replySuccess,

--- a/apps/raincloud/handlers/commandHandler.js
+++ b/apps/raincloud/handlers/commandHandler.js
@@ -1,14 +1,14 @@
 const fs = require('fs');
 const path = require('path');
 const { Collection } = require('discord.js');
-const { createLogger } = require('../dist/utils/logger');
+const { createLogger } = require('@rainbot/utils/logger');
 
 const log = createLogger('COMMANDS');
 
 module.exports = (client) => {
   client.commands = new Collection();
 
-  // Look in commands/ for JS command files (they require from dist/utils/)
+  // Look in commands/ for JS command files (they require @rainbot/utils at runtime)
   const commandsPath = path.join(__dirname, '..', 'commands');
   const commandFolders = fs.readdirSync(commandsPath);
 

--- a/apps/raincloud/handlers/eventHandler.js
+++ b/apps/raincloud/handlers/eventHandler.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const { createLogger } = require('../dist/utils/logger');
+const { createLogger } = require('@rainbot/utils/logger');
 
 const log = createLogger('EVENTS');
 

--- a/apps/raincloud/src/events/guildCreate.js
+++ b/apps/raincloud/src/events/guildCreate.js
@@ -1,6 +1,6 @@
 const { Events } = require('discord.js');
-const { createLogger } = require('../../dist/utils/logger');
-const stats = require('../../dist/utils/statistics');
+const { createLogger } = require('@rainbot/utils/logger');
+const stats = require('@rainbot/utils/statistics');
 
 const log = createLogger('GUILD');
 

--- a/apps/raincloud/src/events/guildDelete.js
+++ b/apps/raincloud/src/events/guildDelete.js
@@ -1,6 +1,6 @@
 const { Events } = require('discord.js');
-const { createLogger } = require('../../dist/utils/logger');
-const stats = require('../../dist/utils/statistics');
+const { createLogger } = require('@rainbot/utils/logger');
+const stats = require('@rainbot/utils/statistics');
 
 const log = createLogger('GUILD');
 

--- a/apps/raincloud/src/events/interactionCreate.js
+++ b/apps/raincloud/src/events/interactionCreate.js
@@ -1,7 +1,7 @@
 const { Events, MessageFlags } = require('discord.js');
-const { createLogger } = require('../../dist/utils/logger');
-const voiceManager = require('../../dist/utils/voiceManager');
-const stats = require('../../dist/utils/statistics');
+const { createLogger } = require('@rainbot/utils/logger');
+const voiceManager = require('@rainbot/utils/voiceManager');
+const stats = require('@rainbot/utils/statistics');
 
 const log = createLogger('INTERACTION');
 

--- a/apps/raincloud/src/events/ready.js
+++ b/apps/raincloud/src/events/ready.js
@@ -1,7 +1,7 @@
 const { Events } = require('discord.js');
-const { createLogger } = require('../../dist/utils/logger');
-const { deployCommands } = require('../../dist/utils/deployCommands');
-const { loadConfig } = require('../../dist/utils/config');
+const { createLogger } = require('@rainbot/utils/logger');
+const { deployCommands } = require('@rainbot/utils/deployCommands');
+const { loadConfig } = require('@rainbot/utils/config');
 
 const log = createLogger('BOT');
 
@@ -13,8 +13,8 @@ module.exports = {
 
     // Restore saved queue snapshots from previous session (crash recovery)
     try {
-      const { restoreAllQueueSnapshots, startAutoSave } = require('../../dist/utils/voiceManager');
-      const { waitForSchema, getPool } = require('../../dist/utils/database');
+      const { restoreAllQueueSnapshots, startAutoSave } = require('@rainbot/utils/voiceManager');
+      const { waitForSchema, getPool } = require('@rainbot/utils/database');
 
       // Wait for database schema to be ready before restoring snapshots
       const pool = getPool();

--- a/apps/raincloud/src/events/voiceStateUpdate.js
+++ b/apps/raincloud/src/events/voiceStateUpdate.js
@@ -5,9 +5,9 @@ const {
   ButtonBuilder,
   ButtonStyle,
 } = require('discord.js');
-const { createLogger } = require('../../dist/utils/logger');
-const listeningHistory = require('../../dist/utils/listeningHistory');
-const stats = require('../../dist/utils/statistics');
+const { createLogger } = require('@rainbot/utils/logger');
+const listeningHistory = require('@rainbot/utils/listeningHistory');
+const stats = require('@rainbot/utils/statistics');
 
 const log = createLogger('VOICE_STATE');
 
@@ -15,7 +15,7 @@ const log = createLogger('VOICE_STATE');
 let voiceManager = null;
 function getVoiceManager() {
   if (!voiceManager) {
-    voiceManager = require('../../dist/utils/voiceManager');
+    voiceManager = require('@rainbot/utils/voiceManager');
   }
   return voiceManager;
 }


### PR DESCRIPTION
Raincloud crashed on PR 202 deploy because chunk 6 missed the JS files.