### PR TITLE
fix(pranjeet): decode each Grok audio delta before concat

### DIFF
--- a/apps/pranjeet/src/voice-agent/grokVoiceAgent.ts
+++ b/apps/pranjeet/src/voice-agent/grokVoiceAgent.ts
@@ -47,7 +47,7 @@ export function createGrokVoiceAgentClient(
 
   let ws: WebSocket | null = null;
   let sessionConfigured = false;
-  let audioDeltas: string[] = [];
+  let audioDeltas: Buffer[] = [];
   let closed = false;
   let _currentResponseId: string | null = null;
   let sessionConfig: {
@@ -217,21 +217,21 @@ export function createGrokVoiceAgentClient(
         break;
       case 'response.output_audio.delta':
         if (typeof event.delta === 'string') {
-          audioDeltas.push(event.delta);
+          // Decode each delta independently. xAI base64-encodes every delta on
+          // its own, so joining the base64 strings and decoding once corrupts
+          // audio: a non-final delta whose byte length isn't a multiple of 3
+          // ends in '=' padding, and Node's base64 decoder halts at the first
+          // embedded '=', silently truncating later deltas → garbled output.
+          audioDeltas.push(Buffer.from(event.delta, 'base64'));
         }
         break;
       case 'response.output_audio.done':
         if (audioDeltas.length > 0) {
-          const b64 = audioDeltas.join('');
+          const pcm = Buffer.concat(audioDeltas);
           audioDeltas = [];
-          try {
-            const pcm = Buffer.from(b64, 'base64');
-            void Promise.resolve(callbacks.onAudioDone(pcm)).catch((e) => {
-              log.warn(`Voice Agent onAudioDone error: ${(e as Error).message}`);
-            });
-          } catch (e) {
-            log.warn(`Voice Agent decode audio failed: ${(e as Error).message}`);
-          }
+          void Promise.resolve(callbacks.onAudioDone(pcm)).catch((e) => {
+            log.warn(`Voice Agent onAudioDone error: ${(e as Error).message}`);
+          });
         }
         break;
       case 'response.done':


### PR DESCRIPTION
## Problem
Pranjeet's Grok voice (`/chat` conversation mode) sometimes produces **garbled / cut-off audio**.

## Root cause
`apps/pranjeet/src/voice-agent/grokVoiceAgent.ts` accumulated xAI realtime `response.output_audio.delta` events as **base64 strings**, joined them, then decoded once:
```js
const b64 = audioDeltas.join('');
const pcm = Buffer.from(b64, 'base64');
```
xAI base64-encodes **each delta independently**. Any non-final delta whose raw byte length isn't a multiple of 3 ends in `=` padding. Node's base64 decoder **halts at the first embedded `=`**, silently truncating every later delta.

Intermittent because it only corrupts when a non-final delta isn't 3-byte aligned — data-dependent per utterance. When only the final delta is unaligned, it plays fine (the 'sometimes works' case).

### Proof
```
orig  : 0102…1314 (20 bytes)
buggy : 01020304050607 (7 bytes)  CORRUPT   <- join base64 strings
fixed : 0102…1314 (20 bytes)      OK        <- decode-then-concat
```

## Fix
Decode each delta to a `Buffer` on arrival and `Buffer.concat` them, so `=` padding is never embedded mid-stream.

## Verification
- Build + `type-check` pass.