### PR TITLE
fix(pranjeet): evict dead Grok voice-agent client on socket close

### DIFF
--- a/apps/pranjeet/src/index.ts
+++ b/apps/pranjeet/src/index.ts
@@ -15,7 +15,10 @@ import {
   setupAutoFollowVoiceStateHandler,
   type GuildState,
 } from '@rainbot/worker-shared';
-import { initVoiceInteractionManager } from '@rainbot/utils/voice/voiceInteractionInstance';
+import {
+  getVoiceInteractionManager,
+  initVoiceInteractionManager,
+} from '@rainbot/utils/voice/voiceInteractionInstance';
 import {
   log,
   PORT,
@@ -251,6 +254,11 @@ setupDiscordClientReadyHandler(client, {
         return createGrokVoiceAgentClient(session.guildId, session.userId, {
           onAudioDone: (pcm) => playVoiceAgentAudio(session.guildId, connection, pcm),
           executeCommand,
+          // Socket dropped (idle timeout / blip / server close): evict the dead
+          // client so the next utterance recreates a fresh one. Without this the
+          // zombie client stays cached and swallows all later audio → silence.
+          onClose: () =>
+            getVoiceInteractionManager()?.removeVoiceAgentClient(session.guildId, session.userId),
         });
       },
       ttsHandler: async (guildId: string, text: string, userId?: string) => {

--- a/packages/utils/src/voice/voiceInteractionManager.ts
+++ b/packages/utils/src/voice/voiceInteractionManager.ts
@@ -395,11 +395,12 @@ export class VoiceInteractionManager implements IVoiceInteractionManager {
   }
 
   /**
-   * Stop listening to a user
+   * Evict and close a cached Voice Agent client (e.g. after its realtime socket
+   * closed). Without this, a dropped socket leaves a dead client in the map and
+   * all later audio is silently swallowed by its closed sendAudio(). After
+   * eviction the next audio chunk lazily creates a fresh client + socket.
    */
-  async stopListening(userId: string, guildId: string): Promise<void> {
-    log.info(`Stopping listening to user ${userId} in guild ${guildId}`);
-
+  removeVoiceAgentClient(guildId: string, userId: string): void {
     const key = `${guildId}:${userId}`;
     const voiceAgent = this.voiceAgentClients.get(key);
     if (voiceAgent) {
@@ -407,6 +408,15 @@ export class VoiceInteractionManager implements IVoiceInteractionManager {
       this.voiceAgentClients.delete(key);
       this.voiceAgentWarnedKeys.delete(key);
     }
+  }
+
+  /**
+   * Stop listening to a user
+   */
+  async stopListening(userId: string, guildId: string): Promise<void> {
+    log.info(`Stopping listening to user ${userId} in guild ${guildId}`);
+
+    this.removeVoiceAgentClient(guildId, userId);
 
     const state = this.states.get(guildId);
     if (!state) return;


### PR DESCRIPTION
## Symptom
In Grok conversation mode (`/chat on`), Pranjeet **intermittently goes totally silent** — joined, mode on, but no response when you talk. Recovers only after leave/rejoin or `/chat` off→on. Config (key/credits/enabled) is fine.

## Root cause
`voiceInteractionManager.ts` caches the realtime Grok client per `guildId:userId` and reuses it forever. When the xAI WebSocket closes (idle timeout, network blip, server restart), `grokVoiceAgent` sets `closed=true` and `sendAudio()` starts silently early-returning — but:
- the dead client **stays in the `voiceAgentClients` map** (eviction only happens in `stopListening`),
- `apps/pranjeet/src/index.ts` passed **no `onClose`**, so `callbacks.onClose?.()` was a no-op and the manager was never told to evict,
- the client has **no reconnect**.

So one socket drop → zombie client → every later utterance swallowed → silence. Intermittent because it depends on whether the socket happened to drop. (Separate from #207, which fixed *garbled* audio.)

## Fix
- Add `VoiceInteractionManager.removeVoiceAgentClient(guildId, userId)` (close + delete from map + clear warned-key); `stopListening` now reuses it.
- Wire the Pranjeet factory's `onClose` → `removeVoiceAgentClient(...)`. A dropped socket evicts the client; the next utterance lazily creates a fresh client and reconnects.

## Verification
- `yarn build:ts` + `type-check` (utils + pranjeet) pass.

## Known gap (follow-up)
A half-open TCP that never emits a close frame would still zombie. A ws-level ping/keepalive would close that gap.