### PR TITLE
feat(pranjeet): make /chat on start listening immediately (fix silent conversation mode)

### DIFF
--- a/apps/pranjeet/src/events/voice-state.ts
+++ b/apps/pranjeet/src/events/voice-state.ts
@@ -1,8 +1,44 @@
 import { Client, Events } from 'discord.js';
+import type { VoiceConnection } from '@discordjs/voice';
 import { ORCHESTRATOR_BOT_ID } from '../config';
 import { guildStates } from '../state/guild-state';
 import { isVoiceInteractionEnabled } from '../voice-interaction';
 import { log } from '../config';
+
+/**
+ * Subscribe the voice-interaction manager to every (non-bot) member currently in
+ * the bot's voice channel. Members already in the channel never fire a
+ * "user joined" event, so this is how we start listening to them — on bot join
+ * (VoiceStateUpdate) and when conversation mode is turned on while already
+ * connected (setConversationListening RPC). Skips users we're already listening
+ * to (startListening is not idempotent — it would double-subscribe).
+ */
+export async function startListeningForChannelMembers(
+  client: Client,
+  guildId: string,
+  connection: VoiceConnection
+): Promise<void> {
+  const { getVoiceInteractionManager } = require('@rainbot/utils/voice/voiceInteractionInstance');
+  const voiceInteractionMgr = getVoiceInteractionManager();
+  if (!voiceInteractionMgr) return;
+
+  const channelId = connection.joinConfig.channelId;
+  const channel = channelId
+    ? client.guilds.cache.get(guildId)?.channels.cache.get(channelId)
+    : undefined;
+  if (!channel?.isVoiceBased() || !('members' in channel)) return;
+
+  for (const [memberId, member] of channel.members) {
+    if (member.user.bot) continue;
+    if (voiceInteractionMgr.isListeningToUser(guildId, memberId)) continue;
+    try {
+      await voiceInteractionMgr.startListening(memberId, guildId, connection);
+      log.info(`✅ Started voice listening for existing user ${member.user.tag ?? memberId}`);
+    } catch (error) {
+      log.debug(`Failed to start voice listening for ${memberId}: ${(error as Error).message}`);
+    }
+  }
+}
 
 export function registerVoiceStateHandlers(client: Client): void {
   client.on(Events.VoiceStateUpdate, async (oldState, newState) => {
@@ -24,23 +60,8 @@ export function registerVoiceStateHandlers(client: Client): void {
     // (they never get a "user joined" event because they were there first)
     if (userId === client.user?.id && newState.channelId === botChannelId) {
       const enabled = await isVoiceInteractionEnabled(guildId);
-      if (enabled && voiceInteractionMgr) {
-        const channel = newState.channel ?? newState.guild?.channels.cache.get(newState.channelId!);
-        if (channel?.isVoiceBased() && 'members' in channel) {
-          for (const [memberId, member] of channel.members) {
-            if (member.user.bot) continue;
-            try {
-              await voiceInteractionMgr.startListening(memberId, guildId, state.connection);
-              log.info(
-                `✅ Started voice listening for existing user ${member.user.tag ?? memberId}`
-              );
-            } catch (error) {
-              log.debug(
-                `Failed to start voice listening for ${memberId}: ${(error as Error).message}`
-              );
-            }
-          }
-        }
+      if (enabled) {
+        await startListeningForChannelMembers(client, guildId, state.connection);
       }
       return;
     }

--- a/apps/pranjeet/src/handlers/rpc.ts
+++ b/apps/pranjeet/src/handlers/rpc.ts
@@ -11,6 +11,9 @@ import { getOrCreateGuildState, getStateForRpc, guildStates } from '../state/gui
 import { speakInGuild } from '../speak';
 import { getGrokReply } from '../chat/grok';
 import { getGrokPersona } from '../redis';
+import { startListeningForChannelMembers } from '../events/voice-state';
+import { getVoiceInteractionManager } from '@rainbot/utils/voice/voiceInteractionInstance';
+import type { Client } from 'discord.js';
 
 export interface PranjeetRpcDeps {
   client: ReturnType<typeof createWorkerDiscordClient>;
@@ -59,6 +62,35 @@ export function createRpcHandlers(deps: PranjeetRpcDeps) {
     return { reply };
   }
 
+  /**
+   * Conversation mode turned on/off from Raincloud (/chat). On enable, start
+   * listening to everyone currently in the channel so the user doesn't have to
+   * rejoin — the existing-member subscription otherwise only fires on bot join.
+   */
+  async function setConversationListening(input: {
+    guildId: string;
+    enabled: boolean;
+  }): Promise<{ success: boolean }> {
+    const mgr = getVoiceInteractionManager();
+    if (!mgr) return { success: false };
+    if (!input.enabled) {
+      await mgr.disableForGuild(input.guildId);
+      return { success: true };
+    }
+    await mgr.enableForGuild(input.guildId);
+    const state = guildStates.get(input.guildId);
+    if (state?.connection) {
+      await startListeningForChannelMembers(
+        client as unknown as Client,
+        input.guildId,
+        state.connection
+      );
+    } else {
+      log.warn(`setConversationListening: no voice connection for guild ${input.guildId} yet`);
+    }
+    return { success: true };
+  }
+
   return {
     getState: getStateForRpc,
     join,
@@ -66,5 +98,6 @@ export function createRpcHandlers(deps: PranjeetRpcDeps) {
     volume,
     speak,
     grokChat,
+    setConversationListening,
   };
 }

--- a/apps/raincloud/commands/voice/chat.js
+++ b/apps/raincloud/commands/voice/chat.js
@@ -3,16 +3,20 @@ const { createLogger } = require('@rainbot/utils/logger');
 
 const log = createLogger('CHAT_CMD');
 
-function getVoiceStateManager() {
+function getMultiBotService() {
   try {
     const { MultiBotService } = require('../../dist/apps/raincloud/lib/multiBotService');
     if (MultiBotService.isInitialized()) {
-      return MultiBotService.getInstance().getVoiceStateManager();
+      return MultiBotService.getInstance();
     }
   } catch (error) {
     log.debug(`MultiBotService not available: ${error.message}`);
   }
   return null;
+}
+
+function getVoiceStateManager() {
+  return getMultiBotService()?.getVoiceStateManager() ?? null;
 }
 
 module.exports = {
@@ -60,6 +64,21 @@ module.exports = {
       });
     const setModeAndReply = async (enabled, message) => {
       await voiceStateManager.setConversationMode(guildId, userId, enabled);
+      // On enable, make Pranjeet actually listen: enabling conversation routing
+      // alone is not enough — voice interaction must be on and the bot must
+      // subscribe to current channel members (otherwise: joined, mode on, but
+      // total silence). On disable we leave voice-control/listening as-is.
+      if (enabled) {
+        const service = getMultiBotService();
+        if (service) {
+          const result = await service.setConversationListening(guildId, true);
+          if (!result?.success) {
+            log.warn(
+              `setConversationListening failed for guild ${guildId}: ${result?.message ?? 'unknown'}`
+            );
+          }
+        }
+      }
       log.info(
         `Conversation mode ${enabled ? 'on' : 'off'} for guild ${guildName} (requested by ${requesterTag})`
       );

--- a/apps/raincloud/lib/multiBotService.ts
+++ b/apps/raincloud/lib/multiBotService.ts
@@ -329,6 +329,21 @@ export class MultiBotService {
   }
 
   /**
+   * Turn conversation mode listening on/off. On enable, also flips the voice-
+   * interaction flag and tells Pranjeet to start listening to everyone already
+   * in the channel so the user does not have to rejoin.
+   */
+  async setConversationListening(
+    guildId: string,
+    enabled: boolean
+  ): Promise<{ success: boolean; message?: string }> {
+    if (enabled) {
+      await this.voiceStateManager.setVoiceInteractionEnabled(guildId, true);
+    }
+    return this.coordinator.setConversationListening(guildId, enabled);
+  }
+
+  /**
    * Play soundboard effect via HungerBot worker
    */
   async playSoundboard(

--- a/apps/raincloud/lib/workerCoordinator.ts
+++ b/apps/raincloud/lib/workerCoordinator.ts
@@ -573,6 +573,32 @@ export class WorkerCoordinator {
   }
 
   /**
+   * Toggle conversation listening on Pranjeet. On enable, Pranjeet starts
+   * listening to everyone currently in the voice channel (no rejoin needed).
+   */
+  async setConversationListening(
+    guildId: string,
+    enabled: boolean
+  ): Promise<{ success: boolean; message?: string }> {
+    const guard = this.guardWorker('pranjeet');
+    if (!guard.ok) {
+      return { success: false, message: guard.error };
+    }
+    try {
+      const result = await this.requestWithRetry(
+        'pranjeet',
+        () => pranjeetClient.setConversationListening.mutate({ guildId, enabled }),
+        true
+      );
+      return { success: result.success };
+    } catch (error: unknown) {
+      const message = getErrorMessage(error);
+      log.error(`setConversationListening failed: ${message}`);
+      return { success: false, message };
+    }
+  }
+
+  /**
    * Play sound effect (HungerBot)
    */
   async playSound(

--- a/packages/rpc/src/routers/pranjeet.ts
+++ b/packages/rpc/src/routers/pranjeet.ts
@@ -38,6 +38,10 @@ const grokChatInputSchema = z.object({
   userId: z.string(),
   text: z.string(),
 });
+const setConversationListeningInputSchema = z.object({
+  guildId: z.string(),
+  enabled: z.boolean(),
+});
 
 export type GetStateInput = z.infer<typeof getStateInputSchema>;
 export type PranjeetGetStateFn = (input?: GetStateInput) => StatusResponse;
@@ -53,6 +57,11 @@ export interface PranjeetHandlers {
   volume?: (input: VolumeRequest) => Promise<VolumeResponse>;
   speak?: (input: SpeakRequest) => Promise<SpeakResponse>;
   grokChat?: (input: { guildId: string; userId: string; text: string }) => Promise<GrokChatResult>;
+  /** Enable/disable conversation listening and (when enabling) start listening to current members. */
+  setConversationListening?: (input: {
+    guildId: string;
+    enabled: boolean;
+  }) => Promise<{ success: boolean }>;
 }
 
 const notImplemented = (): Promise<{ status: 'error'; message: string }> =>
@@ -82,6 +91,12 @@ export function createPranjeetRouter(handlers: PranjeetHandlers) {
       .mutation(
         ({ input }) =>
           handlers.grokChat?.(input) ?? Promise.resolve({ reply: 'Grok chat is not available.' })
+      ),
+    setConversationListening: internalProcedure
+      .input(setConversationListeningInputSchema)
+      .mutation(
+        ({ input }) =>
+          handlers.setConversationListening?.(input) ?? Promise.resolve({ success: false })
       ),
   });
 }

--- a/packages/utils/src/voice/voiceInteractionManager.ts
+++ b/packages/utils/src/voice/voiceInteractionManager.ts
@@ -177,6 +177,11 @@ export class VoiceInteractionManager implements IVoiceInteractionManager {
     return state?.enabled ?? false;
   }
 
+  /** Whether there is already an active listening session for this user. */
+  isListeningToUser(guildId: string, userId: string): boolean {
+    return this.states.get(guildId)?.sessions.get(userId)?.isListening ?? false;
+  }
+
   /**
    * Subscribe to a user's audio stream and attach data/end/error handlers.
    * On stream end, processes the utterance then resubscribes so the next utterance is captured.


### PR DESCRIPTION
## Symptom
`/chat on` → bot joined, conversation mode on, but **total silence, nothing in the log** when you talk. Required also running `/voice-control enable` first — undiscoverable.

## Root cause
Two independent Redis flags:
- `conversation:active_count:<guild>` — routes captured audio to Grok. Set by `/chat on`.
- `voice:interaction:enabled:<guild>` — gates whether Pranjeet **subscribes to the mic at all** (`startListening`). Set only by `/voice-control enable`, the dashboard, or env.

`/chat on` set only the first. With voice interaction off, `isVoiceInteractionEnabled()` is false → `startListening` never runs → no receiver subscription → no audio chunks → nothing logged → silence. And even enabling the flag while already joined subscribes nobody: the existing-member subscription only fires on the bot's own join event.

## Fix — `/chat on` is now self-sufficient
1. Enables voice interaction (`voice:interaction:enabled = 1`) so future joins listen.
2. Pushes a new `setConversationListening` RPC to Pranjeet, which calls `enableForGuild` and subscribes to **everyone already in the channel** — no rejoin needed.

Existing-member subscription logic is extracted to `startListeningForChannelMembers` (reused by the `VoiceStateUpdate` bot-join path) and now skips users already being listened to, since `startListening` is not idempotent (it would double-subscribe the receiver). `/chat off` leaves voice-control/listening as-is (audio just routes back to STT).

Wiring: `chat.js` → `MultiBotService.setConversationListening` → `WorkerCoordinator` → `pranjeetClient.setConversationListening` → RPC handler → `enableForGuild` + `startListeningForChannelMembers`.

## Files
- `packages/rpc/src/routers/pranjeet.ts` — new `setConversationListening` procedure
- `apps/pranjeet/src/handlers/rpc.ts` — handler (enable + subscribe current members)
- `apps/pranjeet/src/events/voice-state.ts` — extracted `startListeningForChannelMembers`, reused on bot-join
- `packages/utils/src/voice/voiceInteractionManager.ts` — `isListeningToUser` guard
- `apps/raincloud/lib/workerCoordinator.ts` + `multiBotService.ts` — call path
- `apps/raincloud/commands/voice/chat.js` — wire enable path

## Verification
- `yarn build:ts` + `yarn type-check` pass (20/20 tasks).
- Changed source is prettier + eslint clean (lint-staged on commit).
- Note: `yarn validate` reports a pre-existing false failure — utils' `prettier:check` scans built `dist/` because it runs from its own dir and never loads the root `.prettierignore`. 0 `src/` warnings. Flagged separately.