### PR TITLE
fix(utils): add .prettierignore so validate ignores dist output

### DIFF
--- a/packages/utils/.prettierignore
+++ b/packages/utils/.prettierignore
@@ -1,0 +1,4 @@
+# Build output
+dist/
+src/**/*.js
+src/**/*.d.ts


### PR DESCRIPTION
## Problem
`yarn validate` consistently fails on `@rainbot/utils#prettier:check`.

`packages/utils/package.json` runs `prettier --check .`. Prettier loads `.prettierignore` only from its CWD, and `packages/utils` was the **only** package missing a local one (11 sibling packages/apps each have theirs). Since turbo's validate/test tasks build first, `packages/utils/dist/` always exists during validate, so prettier scanned ~76 generated `.js`/`.d.ts` files and exited 1. A fresh checkout (no dist) passed, making it look intermittent.

## Fix
Add `packages/utils/.prettierignore` matching the sibling convention (`dist/`, `src/**/*.js`, `src/**/*.d.ts`). No dist files reformatted.

## Verify
`yarn validate` → exit 0, clean.